### PR TITLE
Removing some deprecation warnings (and others)

### DIFF
--- a/client.py
+++ b/client.py
@@ -3,6 +3,7 @@ import warnings
 from collections import OrderedDict
 
 from flwr.client import NumPyClient, ClientApp
+from flwr.common import Context
 from flwr_datasets import FederatedDataset
 import torch
 import torch.nn as nn
@@ -131,7 +132,7 @@ class FlowerClient(NumPyClient):
         return loss, len(testloader.dataset), {"accuracy": accuracy}
 
 
-def client_fn(cid: str):
+def client_fn(ccontext: Context):
     """Create and return an instance of Flower `Client`."""
     return FlowerClient().to_client()
 

--- a/flower_tutorial.py
+++ b/flower_tutorial.py
@@ -11,13 +11,13 @@ from datasets.utils.logging import disable_progress_bar
 from torch.utils.data import DataLoader
 
 import flwr as fl
-from flwr.common import Metrics
+from flwr.common import Metrics, Context
 from flwr_datasets import FederatedDataset
 
 import time
 
 
-DEVICE = torch.device("CPU")  # Try "cuda" to train on GPU
+DEVICE = torch.device("cpu")  # Try "cuda" to train on GPU
 print(
     f"Training on {DEVICE} using PyTorch {torch.__version__} and Flower {fl.__version__}"
 )
@@ -190,7 +190,7 @@ class FlowerClient(fl.client.NumPyClient):
         return float(loss), len(self.valloader), {"accuracy": float(accuracy)}
     
 
-def client_fn(cid: str) -> FlowerClient:
+def client_fn(context: Context) -> FlowerClient:
     """Create a Flower client representing a single organization."""
 
     # Load model
@@ -199,8 +199,8 @@ def client_fn(cid: str) -> FlowerClient:
     # Load data (CIFAR-10)
     # Note: each client gets a different trainloader/valloader, so each client
     # will train and evaluate on their own unique data
-    trainloader = trainloaders[int(cid)]
-    valloader = valloaders[int(cid)]
+    trainloader = trainloaders[int(context.node_config["partition-id"])]
+    valloader = valloaders[int(context.node_config["partition-id"])]
 
     # Create a  single Flower client representing a single organization
     return FlowerClient(net, trainloader, valloader).to_client()
@@ -220,9 +220,9 @@ def weighted_average(metrics: List[Tuple[int, Metrics]]) -> Metrics:
 strategy = fl.server.strategy.FedAvg(
     fraction_fit=1.0,
     fraction_evaluate=0.5,
-    min_fit_clients=1,
-    min_evaluate_clients=2,
-    min_available_clients=1,
+    min_fit_clients=3,
+    min_evaluate_clients=3,
+    min_available_clients=3,
     evaluate_metrics_aggregation_fn=weighted_average,  # <-- pass the metric aggregation function
 )
 

--- a/server.py
+++ b/server.py
@@ -19,9 +19,9 @@ def weighted_average(metrics: List[Tuple[int, Metrics]]) -> Metrics:
 strategy = fl.server.strategy.FedAvg(
     fraction_fit=1.0,
     fraction_evaluate=0.5,
-    min_fit_clients=4,
+    min_fit_clients=2,
     min_evaluate_clients=2,
-    min_available_clients=1,
+    min_available_clients=2,
     evaluate_metrics_aggregation_fn=weighted_average,  # <-- pass the metric aggregation function
 )
 


### PR DESCRIPTION
Small PR to remove the following warning:

```
(ClientAppActor pid=94932) WARNING :   DEPRECATED FEATURE: `client_fn` now expects a signature `def client_fn(context: Context)`.The provided `client_fn` has signature: {'cid': <Parameter "cid: str">}. You can import the `Context` like this: `from flwr.common import Context` [repeated 6x across cluster]
(ClientAppActor pid=94932)          [repeated 12x across cluster]
(ClientAppActor pid=94932)             This is a deprecated feature. It will be removed [repeated 6x across cluster]
(ClientAppActor pid=94932)             entirely in future versions of Flower. [repeated 6x across cluster]
```

and:
```
WARNING :
Setting `min_available_clients` lower than `min_fit_clients` or
`min_evaluate_clients` can cause the server to fail when there are too few clients
connected to the server. `min_available_clients` must be set to a value larger
than or equal to the values of `min_fit_clients` and `min_evaluate_clients`.
```